### PR TITLE
Feature/static method route types

### DIFF
--- a/src/Route.php
+++ b/src/Route.php
@@ -5,19 +5,6 @@ namespace SimpleRoute;
 final class Route implements RouteInterface
 {
     /**
-     * @var array
-     */
-    private static $availableMethods = [
-        'GET',
-        'POST',
-        'PUT',
-        'PATCH',
-        'DELETE',
-        'HEAD',
-        'OPTION',
-    ];
-
-    /**
      * @var string[]
      */
     private $methods;
@@ -50,27 +37,61 @@ final class Route implements RouteInterface
     }
 
     /**
-     * @param string $method    The HTTP method type
-     * @param string $arguments The arguments to allow __construct to be called
-     *
-     * @throws \InvalidArgumentException
+     * @param string $pattern The URI pattern
+     * @param string $handler The handler
      *
      * @return Route
      */
-    public static function __callStatic($method, $arguments)
+    public static function GET($pattern, $handler)
     {
-        if (in_array($method, static::$availableMethods) === false) {
-            throw new \InvalidArgumentException(
-                sprintf('%s is not a valid method', $method)
-            );
-        }
-
-        list($pattern, $handler) = $arguments;
-
-        return new self(
-            $method, $pattern, $handler
-        );
+        return new self(['GET'], $pattern, $handler);
     }
+
+    /**
+     * @param string $pattern The URI pattern
+     * @param string $handler The handler
+     *
+     * @return Route
+     */
+    public static function POST($pattern, $handler)
+    {
+        return new self(['POST'], $pattern, $handler);
+    }
+
+    /**
+     * @param string $pattern The URI pattern
+     * @param string $handler The handler
+     *
+     * @return Route
+     */
+    public static function PUT($pattern, $handler)
+    {
+        return new self(['PUT'], $pattern, $handler);
+    }
+
+    /**
+     * @param string $pattern The URI pattern
+     * @param string $handler The handler
+     *
+     * @return Route
+     */
+    public static function PATCH($pattern, $handler)
+    {
+        return new self(['PATCH'], $pattern, $handler);
+    }
+
+    /**
+     * @param string $pattern The URI pattern
+     * @param string $handler The handler
+     *
+     * @return Route
+     */
+    public static function DELETE($pattern, $handler)
+    {
+        return new self(['DELETE'], $pattern, $handler);
+    }
+
+
 
     /**
      * {@inheritdoc}

--- a/src/Route.php
+++ b/src/Route.php
@@ -14,6 +14,7 @@ final class Route implements RouteInterface
         'PATCH',
         'DELETE',
         'HEAD',
+        'OPTION',
     ];
 
     /**

--- a/src/Route.php
+++ b/src/Route.php
@@ -38,7 +38,7 @@ final class Route implements RouteInterface
 
     /**
      * @param string $pattern The URI pattern
-     * @param string $handler The handler
+     * @param mixed  $handler The handler
      *
      * @return Route
      */
@@ -49,7 +49,7 @@ final class Route implements RouteInterface
 
     /**
      * @param string $pattern The URI pattern
-     * @param string $handler The handler
+     * @param mixed  $handler The handler
      *
      * @return Route
      */
@@ -60,7 +60,7 @@ final class Route implements RouteInterface
 
     /**
      * @param string $pattern The URI pattern
-     * @param string $handler The handler
+     * @param mixed  $handler The handler
      *
      * @return Route
      */
@@ -71,7 +71,7 @@ final class Route implements RouteInterface
 
     /**
      * @param string $pattern The URI pattern
-     * @param string $handler The handler
+     * @param mixed  $handler The handler
      *
      * @return Route
      */
@@ -82,7 +82,7 @@ final class Route implements RouteInterface
 
     /**
      * @param string $pattern The URI pattern
-     * @param string $handler The handler
+     * @param mixed  $handler The handler
      *
      * @return Route
      */

--- a/src/Route.php
+++ b/src/Route.php
@@ -49,6 +49,29 @@ final class Route implements RouteInterface
     }
 
     /**
+     * @param string $method    The HTTP method type
+     * @param string $arguments The arguments to allow __construct to be called
+     *
+     * @throws \InvalidArgumentException
+     *
+     * @return Route
+     */
+    public static function __callStatic($method, $arguments)
+    {
+        if (in_array($method, static::$availableMethods) === false) {
+            throw new \InvalidArgumentException(
+                sprintf('%s is not a valid method', $method)
+            );
+        }
+
+        list($pattern, $handler) = $arguments;
+
+        return new self(
+            $method, $pattern, $handler
+        );
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getMethods()

--- a/src/Route.php
+++ b/src/Route.php
@@ -5,6 +5,18 @@ namespace SimpleRoute;
 final class Route implements RouteInterface
 {
     /**
+     * @var array
+     */
+    private static $availableMethods = [
+        'GET',
+        'POST',
+        'PUT',
+        'PATCH',
+        'DELETE',
+        'HEAD',
+    ];
+
+    /**
      * @var string[]
      */
     private $methods;

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -76,6 +76,15 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo', $route->getHandler());
     }
 
+    public function testRouteHasOPTIONMethod()
+    {
+        $route = Route::OPTION('/foo', 'foo');
+
+        $this->assertEquals(array('OPTION'), $route->getMethods());
+        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('foo', $route->getHandler());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -66,30 +66,4 @@ class RouteTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/foo', $route->getPattern());
         $this->assertEquals('foo', $route->getHandler());
     }
-
-    public function testRouteHasHEADMethod()
-    {
-        $route = Route::HEAD('/foo', 'foo');
-
-        $this->assertEquals(array('HEAD'), $route->getMethods());
-        $this->assertEquals('/foo', $route->getPattern());
-        $this->assertEquals('foo', $route->getHandler());
-    }
-
-    public function testRouteHasOPTIONMethod()
-    {
-        $route = Route::OPTION('/foo', 'foo');
-
-        $this->assertEquals(array('OPTION'), $route->getMethods());
-        $this->assertEquals('/foo', $route->getPattern());
-        $this->assertEquals('foo', $route->getHandler());
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     */
-    public function testInvalidStaticMethodCalled()
-    {
-        Route::WOW('/whoops', 'error');
-    }
 }

--- a/test/RouteTest.php
+++ b/test/RouteTest.php
@@ -21,4 +21,66 @@ class RouteTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('GET', 'POST'), $route->getMethods());
     }
+
+    public function testRouteHasGETMethod()
+    {
+        $route = Route::GET('/foo', 'foo');
+
+        $this->assertEquals(array('GET'), $route->getMethods());
+        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('foo', $route->getHandler());
+    }
+
+    public function testRouteHasPOSTMethod()
+    {
+        $route = Route::POST('/foo', 'foo');
+
+        $this->assertEquals(array('POST'), $route->getMethods());
+        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('foo', $route->getHandler());
+    }
+
+    public function testRouteHasPUTMethod()
+    {
+        $route = Route::PUT('/foo', 'foo');
+
+        $this->assertEquals(array('PUT'), $route->getMethods());
+        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('foo', $route->getHandler());
+    }
+
+    public function testRouteHasPATCHMethod()
+    {
+        $route = Route::PATCH('/foo', 'foo');
+
+        $this->assertEquals(array('PATCH'), $route->getMethods());
+        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('foo', $route->getHandler());
+    }
+
+    public function testRouteHasDELETEMethod()
+    {
+        $route = Route::DELETE('/foo', 'foo');
+
+        $this->assertEquals(array('DELETE'), $route->getMethods());
+        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('foo', $route->getHandler());
+    }
+
+    public function testRouteHasHEADMethod()
+    {
+        $route = Route::HEAD('/foo', 'foo');
+
+        $this->assertEquals(array('HEAD'), $route->getMethods());
+        $this->assertEquals('/foo', $route->getPattern());
+        $this->assertEquals('foo', $route->getHandler());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testInvalidStaticMethodCalled()
+    {
+        Route::WOW('/whoops', 'error');
+    }
 }


### PR DESCRIPTION
Adds the ability for the following to be used:

``` php
Route::GET('/foo', 'foo');
Route::POST('/foo', 'foo');
Route::PUT('/foo', 'foo');
Route::PATCH('/foo', 'foo');
Route::DELETE('/foo', 'foo');
```

Allows the method call to be explicit where required, with the added validation of the method name.

If the method name does not exists an exception of `InvalidArgumentException` is thrown.
